### PR TITLE
Fix broken universal links by moving to URL Schemes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Pack ATHMovil.PurchaseSDK
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: msbuild Source/**/*.csproj /t:restore,rebuild,pack /p:Configuration=Release
+      
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        # A file, directory or wildcard pattern that describes what to upload
+        path: Source/**/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       run: msbuild Source/**/*.csproj /t:restore,rebuild,pack /p:Configuration=Release /p:version=${{ github.ref_name }}
       
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@3
+      uses: actions/upload-artifact@v3
       with:
         # A file, directory or wildcard pattern that describes what to upload
         path: Source/**/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       run: msbuild Source/**/*.csproj /t:restore,rebuild,pack /p:Configuration=Release /p:version=${{ github.ref_name }}
       
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@3
       with:
         # A file, directory or wildcard pattern that describes what to upload
         path: Source/**/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
-name: Pack ATHMovil.PurchaseSDK
+on:
+  push:
+    tags:
+      - '[0-9].[0-9]+.[0-9]+' 
 
-on: [push]
+name: Pack ATHMovil.PurchaseSDK
 
 jobs:
   build:
@@ -11,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Build
-      run: msbuild Source/**/*.csproj /t:restore,rebuild,pack /p:Configuration=Release
+      run: msbuild Source/**/*.csproj /t:restore,rebuild,pack /p:Configuration=Release /p:version=${{ github.ref_name }}
       
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2.2.4

--- a/Source/ATHMovil.PurchaseSDK/ATHMovil.PurchaseSDK.csproj
+++ b/Source/ATHMovil.PurchaseSDK/ATHMovil.PurchaseSDK.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;MonoAndroid10.0;Xamarin.iOS10;</TargetFrameworks>

--- a/Source/ATHMovil.PurchaseSDK/Platforms/iOS/Opener.cs
+++ b/Source/ATHMovil.PurchaseSDK/Platforms/iOS/Opener.cs
@@ -31,7 +31,7 @@ namespace ATHMovil.Purchase.Openers
         {
             string bodyJSON = Encoder.Encode(request);
 
-            string fullPath = target.GetTargetUniversalLink() + GetPathPaymentType(request.Business);
+            string fullPath = target.GetTargetURLScheme() + GetPathPaymentType(request.Business);
             NSUrlComponents components = new NSUrlComponents(fullPath);
             components.QueryItems = new NSUrlQueryItem[1] { new NSUrlQueryItem(Opener.ParameterJSONName, bodyJSON) };
 
@@ -48,7 +48,7 @@ namespace ATHMovil.Purchase.Openers
         private void OpenATHMovil(NSUrl url)
         {
             UIApplicationOpenUrlOptions options = new UIApplicationOpenUrlOptions();
-            options.UniversalLinksOnly = true;
+            options.UniversalLinksOnly = false;
 
             UIApplication.SharedApplication.OpenUrl(url, options, OpenAppStore);
         }
@@ -92,6 +92,11 @@ namespace ATHMovil.Purchase.Openers
         internal static string GetTargetUniversalLink(this ATHMovilTarget target)
         {
             return "https://athm-ulink-prod-static-website.s3.amazonaws.com/e-commerce/";
+        }
+
+        internal static string GetTargetURLScheme(this ATHMovilTarget target)
+        {
+            return "athm://payment/";
         }
     }
 }


### PR DESCRIPTION
This pull request addresses the issue of broken universal links in the SDK, causing apps to attempt opening ATH Móvil on the iTunes Store app. The proposed solution is to move from universal links to URL Schemes to fix the problem. The changes are based on the reference commit [evertec/athmovil-ios-sdk@c08e235](https://github.com/evertec/athmovil-ios-sdk/pull/14/commits/c08e235f185da2d4bbf0fbb19a8ee21b05d95723).

Additionally, this PR includes a GitHub workflow to automate the packaging of the SDK as a NuGet package.

Changes:
Updated Source/ATHMovil.PurchaseSDK/Platforms/iOS/Opener.cs to replace universal links with URL Schemes.
Added .github/workflows/build.yml for NuGet packaging.

Please review the changes and let me know if you have any suggestions or concerns. Looking forward to your feedback!